### PR TITLE
WindowsFormsHost Keyboard shortcut issue

### DIFF
--- a/Dragablz/TabablzControl.cs
+++ b/Dragablz/TabablzControl.cs
@@ -1294,7 +1294,9 @@ namespace Dragablz
             var selectedContent = GetContent(SelectedItem);
             foreach (ContentPresenter child in _itemsHolder.Children)
             {
-                child.Visibility = child.Content == selectedContent ? Visibility.Visible : Visibility.Collapsed;
+                var isSelected = (child.Content == selectedContent);
+                child.Visibility = isSelected ? Visibility.Visible : Visibility.Collapsed;
+                child.IsEnabled = isSelected;
             }
         }
 


### PR DESCRIPTION
Toggle isEnabled to fix issue with WindowsFormsHosts taking keyboard input from inactive tabs