### PR TITLE
Changed GetIsWrappingTabItem to public.

### DIFF
--- a/Dragablz/TabablzControl.cs
+++ b/Dragablz/TabablzControl.cs
@@ -552,7 +552,7 @@ namespace Dragablz
             element.SetValue(IsWrappingTabItemProperty, value);
         }
 
-        internal static bool GetIsWrappingTabItem(DependencyObject element)
+        public static bool GetIsWrappingTabItem(DependencyObject element)
         {
             return (bool) element.GetValue(IsWrappingTabItemProperty);
         }


### PR DESCRIPTION
Changed GetIsWrappingTabItem to public to support custom Xaml files. Closes issue #65.