### PR TITLE
LayoutAccessor.TabablzControl is null if wrapped in grid

### DIFF
--- a/Dragablz/Dockablz/LayoutAccessor.cs
+++ b/Dragablz/Dockablz/LayoutAccessor.cs
@@ -1,5 +1,8 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
+using System.Windows;
+using System.Windows.Media;
 
 namespace Dragablz.Dockablz
 {
@@ -22,7 +25,27 @@ namespace Dragablz.Dockablz
             if (branch != null)
                 _branchAccessor = new BranchAccessor(branch);
             else            
-                _tabablzControl = Layout.Content as TabablzControl;            
+                _tabablzControl = FindVisualChildren<TabablzControl>(Layout).SingleOrDefault();
+        }
+
+        private static IEnumerable<T> FindVisualChildren<T>(DependencyObject depObject) where T : DependencyObject
+        {
+            if (depObject != null)
+            {
+                for (int i = 0; i < VisualTreeHelper.GetChildrenCount(depObject); i++)
+                {
+                    var child = VisualTreeHelper.GetChild(depObject, i);
+                    if (child != null && child is T)
+                    {
+                        yield return (T)child;
+                    }
+
+                    foreach (T childOfChild in FindVisualChildren<T>(child))
+                    {
+                        yield return childOfChild;
+                    }
+                }
+            }
         }
 
         public Layout Layout


### PR DESCRIPTION
Hi

I ran into this issue where if you wrap the TabablzControl (inside the Layout), in a Grid element like so:

        <Grid>
            <dragablz:TabablzControl x:Name="InitialTabablzControl"
                                 FixedHeaderCount="1"
                                 Style="{StaticResource TabablzControlStyle}"
                                 AddLocationHint="After">
                <dragablz:TabablzControl.InterTabController>
                    <dragablz:InterTabController InterTabClient="{Binding InterTabClient}" Partition="2AE89D18-F236-4D20-9605-6C03319038E6" />
                </dragablz:TabablzControl.InterTabController>
            </dragablz:TabablzControl>
        </Grid>

It can be reproduced in the BoundExampleWindow.xaml sample.
After wrapping in Grid, the "Query Layouts" no longer works.

After wrapping the element in Grid, the LayoutAccessor can no longer find the tabablzControl as this is not the direct child of the Layout element.

The LayoutAccessor currently does this

            var branch = Layout.Content as Branch;
            if (branch != null)
                _branchAccessor = new BranchAccessor(branch);
            else
            {
                _tabablzControl = Layout.Content as TabablzControl;
            }

But after wrapping the TabablzControl in the grid, like above. The above line results in null, as Grid cant be converted to TabablzControl type.

I figure it should instead traverse down untill it finds the TabablzControl.

--------------

Changed LayouAccessor constructor to look for TabablzControl instead of just (trying to) convert Layout.Content to TabablzControl.