### PR TITLE
Add a static helper method to TabablzControl to close tabs

### DIFF
--- a/Dragablz/TabablzControl.cs
+++ b/Dragablz/TabablzControl.cs
@@ -1482,16 +1482,6 @@ namespace Dragablz
             if (owner == null) throw new ApplicationException("Unable to ascertain DragablzItem to close.");
 
             CloseItem(owner.Item1, owner.Item2);
-            /*var cancel = false;
-            if (owner.Item2.ClosingItemCallback != null)
-            {
-                var callbackArgs = new ItemActionCallbackArgs<TabablzControl>(Window.GetWindow(owner.Item2), owner.Item2, owner.Item1);
-                owner.Item2.ClosingItemCallback(callbackArgs);
-                cancel = callbackArgs.IsCancelled;
-            }
-
-            if (!cancel)
-                owner.Item2.RemoveItem(owner.Item1);*/
         }
 
         private static Tuple<DragablzItem, TabablzControl> FindOwner(object eventParameter, object eventOriginalSource)

--- a/Dragablz/TabablzControl.cs
+++ b/Dragablz/TabablzControl.cs
@@ -94,6 +94,28 @@ namespace Dragablz
         }
 
         /// <summary>
+        /// Helper method to close all tabs where the item is the tab's content (helpful with MVVM scenarios)
+        /// </summary>
+        /// <remarks>
+        /// In MVVM scenarios where you don't want to bind the routed command to your ViewModel,
+        /// with this helper method and embedding the TabablzControl in a UserControl, you can keep
+        /// the View-specific dependencies out of the ViewModel.
+        /// </remarks>
+        /// <param name="tabContentItem">An existing Tab item content (a ViewModel in MVVM scenarios) which is backing a tab control</param>
+        public static void CloseItem(object tabContentItem)
+        {
+            if (tabContentItem == null) return; //Do nothing.
+
+            //Find all loaded TabablzControl instances with tabs backed by this item and close them
+            foreach(var existingTabWithItemContent in 
+                GetLoadedInstances().SelectMany(tc => tc._dragablzItemsControl.DragablzItems().Where(di => di.Content.Equals(tabContentItem))))
+            {
+                if (TabablzControl.CloseItemCommand.CanExecute(existingTabWithItemContent, null))
+                    TabablzControl.CloseItemCommand.Execute(existingTabWithItemContent, null);
+            }
+        }
+
+        /// <summary>
         /// Helper method to add an item next to an existing item.
         /// </summary>
         /// <remarks>


### PR DESCRIPTION
I've found when using the TabablzControl in MVVM applications that removing ViewModels bound in through the ItemsSource don't trigger the proper clean up paths in TabablzControl (unlike when triggering the RoutedCommand "CloseItemCommand").

To address this without requiring routed command handlers in the ViewModel, I've added a static helper method to TabablzControl called "CloseItem". It takes an object, which is expected to be the Content (in the MVVM case, the ViewModel) backing the tab that should be closed. The method locates all open tabs backed by the ViewModel and calls the CloseItemCommand for each tab.