### PR TITLE
Fixed exception on drag in applications with multiple UI threads

### DIFF
--- a/Dragablz/Dockablz/Layout.cs
+++ b/Dragablz/Dockablz/Layout.cs
@@ -669,7 +669,7 @@ namespace Dragablz.Dockablz
             _isDragOpWireUpPending = false;
 
             foreach (var loadedLayout in LoadedLayouts)
-                loadedLayout.IsParticipatingInDrag = false;
+                loadedLayout.Dispatcher.Invoke(new Action(() => { loadedLayout.IsParticipatingInDrag = false; }));
 
             if (_currentlyOfferedDropZone == null || e.DragablzItem.IsDropTargetFound) return;
 
@@ -723,8 +723,11 @@ namespace Dragablz.Dockablz
                 _isDragOpWireUpPending = false;
             }
 
-            foreach (var layout in LoadedLayouts.Where(l => l.IsParticipatingInDrag))
-            {                
+            foreach (var layout in LoadedLayouts)
+            {
+                var isParticipating = false;
+                layout.Dispatcher.Invoke(new Action(() => { isParticipating = layout.IsParticipatingInDrag; }));
+                if (!isParticipating) continue;
                 var cursorPos = Native.GetCursorPos();
                 layout.MonitorDropZones(cursorPos);
             }         


### PR DESCRIPTION
Added `Dispatcher.Invoke()` when accessing the `IsParticipatingInDrag` dependency property while iterating all layout instances (some of which may be on different UI threads). See #198.