### PR TITLE
Update SecondaryAccentBrush to SecondaryHueMidBrush

### DIFF
--- a/Dragablz/Themes/MaterialDesign.xaml
+++ b/Dragablz/Themes/MaterialDesign.xaml
@@ -149,7 +149,7 @@
         <Setter Property="Foreground" Value="{DynamicResource PrimaryHueMidForegroundBrush}"/>
         <Setter Property="Background" Value="Transparent"/>
         <Setter Property="BorderBrush" Value="Transparent"/>
-        <Setter Property="local:MaterialDesignAssist.IndicatorBrush" Value="{DynamicResource SecondaryAccentBrush}" />
+        <Setter Property="local:MaterialDesignAssist.IndicatorBrush" Value="{DynamicResource SecondaryHueMidBrush}" />
         <Setter Property="Margin" Value="0 0 0 0"/>
         <Setter Property="Padding" Value="8"/>
         <Setter Property="MinWidth" Value="80" />
@@ -267,7 +267,7 @@
                                 </Grid>
                             </local:Ripple>
                         </Border>
-                        <Border x:Name="SelectionHighlightBorder" Background="{DynamicResource SecondaryAccentBrush}" Width="2"
+                        <Border x:Name="SelectionHighlightBorder" Background="{DynamicResource SecondaryHueMidBrush}" Width="2"
                                 Grid.Column="1"
                                 Visibility="Hidden"/>
                     </Grid>


### PR DESCRIPTION
Dragablz material theme doesn't show the selected tab indicator with the accent brush since the materialdesigntheme brush names were changed. 